### PR TITLE
Bugfix/empty feature files cause errors

### DIFF
--- a/lib/chutney/linter/avoid_colons_at_start_of_names.rb
+++ b/lib/chutney/linter/avoid_colons_at_start_of_names.rb
@@ -4,7 +4,9 @@ module Chutney
   # service class to lint for avoiding colons at the start of names
   class AvoidColonsAtStartOfNames < Linter
     def lint
-      add_issue(I18n.t('linters.avoid_colons_at_start_of_names'), feature) if feature.name.start_with? ':'
+      unless feature.nil?
+        add_issue(I18n.t('linters.avoid_colons_at_start_of_names'), feature) if feature.name.start_with? ':'
+      end
 
       scenarios do |_feature, scenario|
         if scenario.name.start_with? ':'

--- a/lib/chutney/linter/avoid_colons_at_start_of_names.rb
+++ b/lib/chutney/linter/avoid_colons_at_start_of_names.rb
@@ -4,9 +4,9 @@ module Chutney
   # service class to lint for avoiding colons at the start of names
   class AvoidColonsAtStartOfNames < Linter
     def lint
-      unless feature.nil?
-        add_issue(I18n.t('linters.avoid_colons_at_start_of_names'), feature) if feature.name.start_with? ':'
-      end
+      return if feature.nil?
+
+      add_issue(I18n.t('linters.avoid_colons_at_start_of_names'), feature) if feature.name.start_with? ':'
 
       scenarios do |_feature, scenario|
         if scenario.name.start_with? ':'

--- a/lib/chutney/version.rb
+++ b/lib/chutney/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Chutney
-  VERSION = '3.10.0'
+  VERSION = '3.10.1'
 end


### PR DESCRIPTION
Chutney was breaking when trying to lint a feature file that was all commented out.

This PR adds a guard clause at the beginning of this method to jump to the method if `feature` is nil